### PR TITLE
rf(py314): Replace deprecated pkgutil.find_loader

### DIFF
--- a/ifsnipype/base/python.py
+++ b/ifsnipype/base/python.py
@@ -35,11 +35,11 @@ class LibraryBaseInterface(BaseInterface):
     def __init__(self, check_import=True, *args, **kwargs):
         super(LibraryBaseInterface, self).__init__(*args, **kwargs)
         if check_import:
-            import pkgutil
+            import importlib.util
 
             failed_imports = []
             for pkg in (self._pkg,) + tuple(self.imports):
-                if pkgutil.find_loader(pkg) is None:
+                if importlib.util.find_spec(pkg) is None:
                     failed_imports.append(pkg)
             if failed_imports:
                 iflogger.warning(


### PR DESCRIPTION
This PR removes [pkgutil.find_loader()][] and replaces it with [importlib.util.find_spec()][]. `find_loader` was deprecated in Python 3.12 and will be removed in 3.14. `find_spec` has been present since Python 3.4.

Both functions return `None` if the module loader cannot be found. For its use in this project, this is sufficient and no translation of the return value is needed.

[pkgutil.find_loader()]: https://docs.python.org/3/library/pkgutil.html#pkgutil.get_loader
[importlib.util.find_spec()]: https://docs.python.org/3/library/importlib.html#importlib.util.find_spec
